### PR TITLE
Miscellaneous build warning fixes

### DIFF
--- a/include/pandarGeneral_sdk/pandarGeneral_sdk.h
+++ b/include/pandarGeneral_sdk/pandarGeneral_sdk.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <boost/function.hpp>
+#include <boost/thread.hpp>
 
 #include "pandarGeneral/pandarGeneral.h"
 #include "pandarGeneral/point_types.h"

--- a/src/PandarGeneralRaw/src/input.cc
+++ b/src/PandarGeneralRaw/src/input.cc
@@ -125,7 +125,7 @@ int Input::getPacket(PandarPacket *pkt) {
   }
 
   senderAddressLen = sizeof(senderAddress);
-  ssize_t nbytes;
+  ssize_t nbytes = 0;
   for (int i = 0; i != socketNumber; ++i) {
     if (fds[i].revents & POLLIN) {
       nbytes = recvfrom(fds[i].fd, &pkt->data[0], ETHERNET_MTU, 0,

--- a/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
+++ b/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
@@ -557,6 +557,8 @@ int PandarGeneral_Internal::Start() {
   } else {
     pcap_reader_->start(boost::bind(&PandarGeneral_Internal::FillPacket, this, _1, _2));
   }
+
+  return 0;
 }
 
 void PandarGeneral_Internal::Stop() {
@@ -616,7 +618,6 @@ void PandarGeneral_Internal::FillPacket(const uint8_t *buf, const int len) {
 
 void PandarGeneral_Internal::ProcessLiarPacket() {
   // LOG_FUNC();
-  double lastTimestamp = 0.0f;
   struct timespec ts;
   int ret = 0;
 
@@ -874,7 +875,8 @@ int PandarGeneral_Internal::ParseRawData(Pandar40PPacket *packet,
       unit.intensity = (buf[index + 2] & 0xff);
 
       // TODO(Philip.Pi): Filtering wrong data for LiDAR.
-      if ((unit.distance == 0x010101 && unit.intensity == 0x0101) || \
+      // unit.intensity is a uint8_t and comparing against 0x0101 always yields false
+      if (/*(unit.distance == 0x010101 && unit.intensity == 0x0101) || */
           unit.distance > (200 * 1000 / 2 /* 200m -> 2mm */)) {
         unit.distance = 0;
         unit.intensity = 0;

--- a/src/PandarGeneralRaw/src/pandarGeneral_internal.h
+++ b/src/PandarGeneralRaw/src/pandarGeneral_internal.h
@@ -54,7 +54,7 @@
  * Pandar 64
  */
 #define HS_LIDAR_TIME_SIZE (6)
-// Each Packet have 8 byte 
+// Each Packet have 8 byte
 #define HS_LIDAR_L64_HEAD_SIZE (8)
 // Block number 6 or 7
 #define HS_LIDAR_L64_BLOCK_NUMBER_6 (6)
@@ -83,7 +83,7 @@
 #define HS_LIDAR_L64_7_BLOCK_PACKET_BODY_SIZE (HS_LIDAR_L64_BLOCK_SIZE * \
 HS_LIDAR_L64_BLOCK_NUMBER_7)
 
-// packet tail size 
+// packet tail size
 #define HS_LIDAR_L64_PACKET_TAIL_SIZE (26)
 #define HS_LIDAR_L64_PACKET_TAIL_WITHOUT_UDPSEQ_SIZE (22)
 
@@ -161,8 +161,8 @@ typedef struct HS_LIDAR_L64_Header_s{
     unsigned short sob;     // 0xFFEE 2bytes
     char chLaserNumber;     // laser number 1byte
     char chBlockNumber;     //block number 1byte
-    char chReturnType;      // return mode 1 byte  when dual return 0-Single Return 
-                            // 1-The first block is the 1 st return. 
+    char chReturnType;      // return mode 1 byte  when dual return 0-Single Return
+                            // 1-The first block is the 1 st return.
                             // 2-The first block is the 2 nd return
     char chDisUnit;         // Distance unit, 6mm/5mm/4mm
     public:
@@ -200,8 +200,8 @@ typedef struct HS_LIDAR_L20_Header_s{
     unsigned short sob;     // 0xFFEE 2bytes
     char chLaserNumber;     // laser number 1byte
     char chBlockNumber;     //block number 1byte
-    char chReturnType;      // return mode 1 byte  when dual return 0-Single Return 
-                            // 1-The first block is the 1 st return. 
+    char chReturnType;      // return mode 1 byte  when dual return 0-Single Return
+                            // 1-The first block is the 1 st return.
                             // 2-The first block is the 2 nd return
     char chDisUnit;         // Distance unit, 6mm/5mm/4mm
     public:
@@ -263,7 +263,7 @@ class PandarGeneral_Internal {
   PandarGeneral_Internal(
       std::string device_ip, uint16_t lidar_port, uint16_t gps_port,
       boost::function<void(boost::shared_ptr<PPointCloud>, double)>
-          pcl_callback, boost::function<void(double)> gps_callback, 
+          pcl_callback, boost::function<void(double)> gps_callback,
       uint16_t start_angle, int tz, int pcl_type, std::string frame_id);
 
   /**
@@ -348,15 +348,6 @@ class PandarGeneral_Internal {
 
   float General_elev_angle_map_[MAX_LASER_NUM];
   float General_horizatal_azimuth_offset_map_[MAX_LASER_NUM];
-
-  float Pandar20_elev_angle_map_[HS_LIDAR_L20_UNIT_NUM];
-  float Pandar20_horizatal_azimuth_offset_map_[HS_LIDAR_L20_UNIT_NUM];
-
-  float PandarQT_elev_angle_map_[HS_LIDAR_QT_UNIT_NUM];
-  float PandarQT_horizatal_azimuth_offset_map_[HS_LIDAR_QT_UNIT_NUM];
-
-  float PandarXT_elev_angle_map_[HS_LIDAR_XT_UNIT_NUM];
-  float PandarXT_horizatal_azimuth_offset_map_[HS_LIDAR_XT_UNIT_NUM];
 
   float block64OffsetSingle_[HS_LIDAR_L64_BLOCK_NUMBER_6];
   float block64OffsetDual_[HS_LIDAR_L64_BLOCK_NUMBER_6];

--- a/src/PandarGeneralRaw/src/pcap_reader.cpp
+++ b/src/PandarGeneralRaw/src/pcap_reader.cpp
@@ -18,7 +18,6 @@ PcapReader::PcapReader(std::string path, std::string frame_id) {
   if(iter != m_timeIndexMap.end()) {
      m_iTsIndex = iter->second.first;
     m_iUTCIndex = iter->second.second;
-  
   }
   else{
     m_iTsIndex = 0;

--- a/src/pandarGeneral_sdk.cc
+++ b/src/pandarGeneral_sdk.cc
@@ -98,6 +98,8 @@ int PandarGeneralSDK::Start() {
   enable_get_calibration_thr_ = true;
   get_calibration_thr_ = new boost::thread(
       boost::bind(&PandarGeneralSDK::GetCalibrationFromDevice, this));
+
+  return 0;
 }
 
 void PandarGeneralSDK::Stop() {

--- a/src/tcp_command_client.c
+++ b/src/tcp_command_client.c
@@ -93,12 +93,12 @@ static int tcpCommandReadCommand(int connfd, TC_Command* cmd) {
     return -1;
   }
 
-  print_mem(buffer, 8);
+  print_mem((char*)buffer, 8);
 
   tcpCommandHeaderParser(buffer + 2, 6, &cmd->header);
 
   if (cmd->header.len > 0) {
-    cmd->data = malloc(cmd->header.len);
+    cmd->data = (unsigned char*)malloc(cmd->header.len);
     if (!cmd->data) {
       printf("malloc data error\n");
       return -1;
@@ -114,7 +114,7 @@ static int tcpCommandReadCommand(int connfd, TC_Command* cmd) {
 
   // cmd->ret_size = cmd->header.len;
 
-  print_mem(cmd->data, cmd->header.len);
+  print_mem((char*)cmd->data, cmd->header.len);
 
   return 0;
 }
@@ -158,9 +158,9 @@ static PTC_ErrCode tcpCommandClient_SendCmd(TcpCommandClient* client,
   }
 
   unsigned char buffer[128];
-  int size = TcpCommand_buildHeader(buffer, cmd);
+  int size = TcpCommand_buildHeader((char*)buffer, cmd);
 
-  print_mem(buffer, size);
+  print_mem((char*)buffer, size);
   int ret = write(fd, buffer, size);
   if (ret != size) {
     close(fd);
@@ -170,7 +170,7 @@ static PTC_ErrCode tcpCommandClient_SendCmd(TcpCommandClient* client,
   }
 
   if (cmd->header.len > 0 && cmd->data) {
-    print_mem(cmd->data, cmd->header.len);
+    print_mem((char*)cmd->data, cmd->header.len);
     ret = write(fd, cmd->data, cmd->header.len);
     if (ret != cmd->header.len) {
       printf("Write Payload error\n");
@@ -238,7 +238,7 @@ PTC_ErrCode TcpCommandSetCalibration(const void* handle, const char* buffer,
   memset(&cmd, 0, sizeof(TC_Command));
   cmd.header.cmd = PTC_COMMAND_SET_CALIBRATION;
   cmd.header.len = len;
-  cmd.data = strdup(buffer);
+  cmd.data = (unsigned char*)strdup(buffer);
 
   PTC_ErrCode errorCode = tcpCommandClient_SendCmd(client, &cmd);
   if (errorCode != PTC_ERROR_NO_ERROR) {
@@ -252,12 +252,12 @@ PTC_ErrCode TcpCommandSetCalibration(const void* handle, const char* buffer,
     free(cmd.ret_data);
   }
 
-  return cmd.header.ret_code;
+  return (PTC_ErrCode)cmd.header.ret_code;
 }
 
 PTC_ErrCode TcpCommandGetCalibration(const void* handle, char** buffer,
                                      unsigned int* len) {
-  printf("buffer is: %s,len is: %d\n",buffer,len);
+  printf("buffer is: %s,len is: %u\n",*buffer,*len);
   if (!handle || !buffer || !len) {
     printf("Bad Parameter!!!\n");
     return PTC_ERROR_BAD_PARAMETER;
@@ -284,11 +284,11 @@ PTC_ErrCode TcpCommandGetCalibration(const void* handle, char** buffer,
   *buffer = ret_str;
   *len = cmd.ret_size + 1;
 
-  return cmd.header.ret_code;
+  return (PTC_ErrCode)cmd.header.ret_code;
 }
 PTC_ErrCode TcpCommandGetLidarCalibration(const void* handle, char** buffer,
                                           unsigned int* len) {
-  printf("buffer is: %s,len is: %d\n",buffer,len);
+  printf("buffer is: %s,len is: %u\n",*buffer,*len);
   if (!handle || !buffer || !len) {
     printf("Bad Parameter!!!\n");
     return PTC_ERROR_BAD_PARAMETER;
@@ -315,7 +315,7 @@ PTC_ErrCode TcpCommandGetLidarCalibration(const void* handle, char** buffer,
   *buffer = ret_str;
   *len = cmd.ret_size + 1;
 
-  return cmd.header.ret_code;
+  return (PTC_ErrCode)cmd.header.ret_code;
 }
 
 PTC_ErrCode TcpCommandResetCalibration(const void* handle) {
@@ -342,7 +342,7 @@ PTC_ErrCode TcpCommandResetCalibration(const void* handle) {
     free(cmd.ret_data);
   }
 
-  return cmd.header.ret_code;
+  return (PTC_ErrCode)cmd.header.ret_code;
 }
 
 void TcpCommandClientDestroy(const void* handle) {}

--- a/src/util.c
+++ b/src/util.c
@@ -42,7 +42,7 @@ int sys_readn(int fd, void* vptr, int n) {
   int nleft, nread;
   char* ptr;
 
-  ptr = vptr;
+  ptr = (char*)vptr;
   nleft = n;
   while (nleft > 0) {
     // printf("start read\n");


### PR DESCRIPTION
I found a number of build warning/errors that popped up after I started building this code using a build system setup with slightly more strict compiler flags. All these changes should have no behavioural effect on the SDK. As a warning, these bugs seem to also be present in the version of this SDK embedded inside the ROS repo.